### PR TITLE
Convert celery options to appropriate types

### DIFF
--- a/pyramid_celery/__init__.py
+++ b/pyramid_celery/__init__.py
@@ -2,23 +2,62 @@ from celery import Celery
 
 from celery.app import App
 
+from celery.app import defaults
 from celery.loaders import default as _default
 from celery.utils import get_full_cls_name
 
 celery = Celery()
 Task = celery.create_task_cls()
 
+
 def includeme(config):
     celery.config_from_object(config.registry.settings)
     celery.config = config
+
+
+TYPES_TO_OBJ = {
+    'any': (object, None),
+    'bool': (bool, defaults.str_to_bool),
+    'dict': (dict, eval),
+    'float': (float, float),
+    'int': (int, int),
+    'list': (list, eval),
+    'tuple': (tuple, eval),
+}
+
+OPTIONS = {
+    key: TYPES_TO_OBJ[opt.type]
+    for key, opt in defaults.flatten(defaults.NAMESPACES)
+    if opt.type != 'string'
+}
+
+
+def convert_celery_options(config):
+    """
+    Converts celery options to apropriate types
+    """
+
+    for key, value in config.iteritems():
+        opt_type = OPTIONS.get(key)
+        if opt_type:
+            if opt_type[0] is object:
+                try:
+                    config[key] = eval(value)
+                except:
+                    pass  # any can be anything; even a string
+            elif not isinstance(value, opt_type[0]):
+                config[key] = opt_type[1](value)
+
 
 class PyramidLoader(_default.Loader):
 
     def read_configuration(self):
         config = self.app.env['registry'].settings
+        convert_celery_options(config)
         settings = self.setup_settings(config)
         self.configured = True
         return settings
+
 
 class Celery(App):
     loader_cls = get_full_cls_name(PyramidLoader)

--- a/pyramid_celery/tests/test_celery.py
+++ b/pyramid_celery/tests/test_celery.py
@@ -23,7 +23,12 @@ class TestCelery(unittest.TestCase):
         settings = {
                 'CELERY_ALWAYS_EAGER': 'true',
                 'CELERYD_CONCURRENCY': '1',
+                'BROKER_TRANSPORT_OPTIONS': '{"foo": "bar"}',
                 'ADMINS': '(("Foo Bar", "foo@bar"), ("Baz Qux", "baz@qux"))',
+                'CELERYD_ETA_SCHEDULER_PRECISION': '0.1',
+                'CASSANDRA_SERVERS': '["foo", "bar"]',
+                'CELERY_ANNOTATIONS': '[1, 2, 3]',   # any
+                'CELERY_ROUTERS': 'some.string',  # also any
                 'SOME_KEY': 'SOME VALUE',
         }
         registry = Mock()
@@ -41,12 +46,20 @@ class TestCelery(unittest.TestCase):
         assert settings == new_settings
         assert celery.env == env
 
+        # Check conversions
         assert new_settings['CELERY_ALWAYS_EAGER'] == True
         assert new_settings['CELERYD_CONCURRENCY'] == 1
         assert new_settings['ADMINS'] == (
                 ("Foo Bar", "foo@bar"),
                 ("Baz Qux", "baz@qux")
         )
+        assert new_settings['BROKER_TRANSPORT_OPTIONS'] == {"foo": "bar"}
+        assert new_settings['CELERYD_ETA_SCHEDULER_PRECISION'] > 0.09
+        assert new_settings['CELERYD_ETA_SCHEDULER_PRECISION'] < 0.11
+        assert new_settings['CASSANDRA_SERVERS'] == ["foo", "bar"]
+        assert new_settings['CELERY_ANNOTATIONS'] == [1, 2, 3]
+        assert new_settings['CELERY_ROUTERS'] == 'some.string'
+        assert new_settings['SOME_KEY'] == settings['SOME_KEY']
 
     @patch('pyramid_celery.celeryd.Celery')
     @patch('pyramid_celery.celeryd.WorkerCommand')


### PR DESCRIPTION
Hi,

so this is my second try. Everything is nice and peachy except for one catch: `CELERY_ANNOTATIONS` doesn't work because read_configuration isn't ran before it tries to apply the configuration. So anything except for a string fails.

Is there maybe some better place to hook the convert function in, than `read_configuration()`? As a pyramid newbie, I don't know where to look at…still, I hope this patch is of any use. As said, I'm already dependent on it. :)

Cheers,
Hynek
