### PR TITLE
Fix for installing with pip and easy_install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md CHANGES.txt


### PR DESCRIPTION
the current tarball does not install with pip or easy_install because README.md and CHANGES.txt are not included.

I added MANIFEST.in to specify that both file need to be included.
