### PR TITLE
Use argparse to handle commandline options

### DIFF
--- a/pyramid_celery/celeryd.py
+++ b/pyramid_celery/celeryd.py
@@ -1,25 +1,19 @@
 #!/usr/bin/env python
-import os
-import sys
+import argparse
 from celery.bin.celeryd import WorkerCommand
 from pyramid.paster import bootstrap
 from pyramid_celery import Celery
 
-def usage(argv):# pragma: no cover 
-    cmd = os.path.basename(argv[0])
-    print('usage: %s <config_uri>\n'
-          '(example: "%s development.ini")' % (cmd, cmd)) 
-    sys.exit(1)
 
-def main(argv=sys.argv): # pragma: no cover
-    if len(argv) != 2:
-        usage(argv)
-
-    config_uri = argv[1]
-
-    env = bootstrap(config_uri)
+def main(): # pragma: no cover
+    parser = argparse.ArgumentParser(description='Celery worker daemon')
+    parser.add_argument('config', metavar='<ini-file>',
+            help='Configuration file (and optionally section)')
+    options = parser.parse_args()
+    env = bootstrap(options.config)
     worker = WorkerCommand(app=Celery(env))
     worker.run()
+
 
 if __name__ == "__main__": # pragma: no cover
     main()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-
+import sys
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -7,9 +7,11 @@ README = open(os.path.join(here, 'README.md')).read()
 CHANGES = open(os.path.join(here, 'CHANGES.txt')).read()
 
 requires = ['pyramid', 'celery']
+if sys.version_info < (2, 7):
+    requires.append('argparse')
 
 setup(name='pyramid_celery',
-      version='0.0',
+      version='1.0dev',
       description='Celery integration with pyramid',
       long_description=README + '\n\n' +  CHANGES,
       classifiers=[
@@ -35,4 +37,3 @@ setup(name='pyramid_celery',
         pceleryd = pyramid_celery.celeryd:main
       """,
       )
-


### PR DESCRIPTION
This has several advantages:
- no need to do any parsing or create help-texts yourself
- --help/-h options automatically supported
- better error messages
