### PR TITLE
pcelerybeat is not working

### DIFF
--- a/pyramid_celery/__init__.py
+++ b/pyramid_celery/__init__.py
@@ -1,3 +1,7 @@
+# used by celerybeat
+from datetime import timedelta
+from celery.schedules import crontab
+
 from celery.app import default_app
 from celery.app import defaults
 


### PR DESCRIPTION
CELERYBEAT_SCHEDULE key extracted from the .ini file use "timedelta" or "cron" for the convenience.
( http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html )

if it's not imported in pyramid_celery, it's unusable.
