### PR TITLE
Hotfix for celery 3.0 compatability

### DIFF
--- a/pyramid_celery/__init__.py
+++ b/pyramid_celery/__init__.py
@@ -5,6 +5,12 @@ from celery.schedules import crontab
 from celery.app import default_app
 from celery.app import defaults
 
+def str_to_bool(term, table={"false": False, "no": False, "0": False,
+                             "true":  True, "yes": True,  "1": True}):
+    try:
+        return table[term.lower()]
+    except KeyError:
+        raise TypeError("Can't coerce %r to type bool" % (term, ))
 
 def clean_quoted_config(config, key):
     # ini doesn't allow quoting, but lets support it to fit with celery
@@ -12,7 +18,7 @@ def clean_quoted_config(config, key):
 
 TYPES_TO_OBJ = {
     'any': (object, None),
-    'bool': (bool, defaults.str_to_bool),
+    'bool': (bool, str_to_bool),
     'dict': (dict, eval),
     'float': (float, float),
     'int': (int, int),


### PR DESCRIPTION
This is a quick hotfix for celery 3.0 compatability, allows projects using the old celery 2.5 API to use pyramid_celery with celery 3.0

str_to_bool is still available in celery 3.0 but in a different location (celery.utils) and a different name (strtobool). Should probably switch to using that once the actual upgrade is performed.
