### PR TITLE
Ensure celery uses the correct backend set in conf

### DIFF
--- a/pyramid_celery/tests/test_celery.py
+++ b/pyramid_celery/tests/test_celery.py
@@ -103,3 +103,29 @@ class TestCelery(unittest.TestCase):
 #        workercommand.assert_called_with(app=celery(env))
 #        bootstrap.assert_called_with('config.ini')
 #        run.assert_called_once_with()
+
+    def test_result_backend(self):
+
+        from pyramid_celery import includeme
+        from celery.app import default_app
+        from celery.backends.redis import RedisBackend
+        from celery.backends.amqp import AMQPBackend
+
+        config = Mock()
+        config.registry = Mock()
+
+        settings = {
+            'CELERY_RESULT_BACKEND': '"amqp"'
+        }
+        config.registry.settings = settings
+
+        includeme(config)
+        self.assertIsInstance(default_app.backend, AMQPBackend)
+
+        settings = {
+            'CELERY_RESULT_BACKEND': '"redis"'
+        }
+        config.registry.settings = settings
+
+        includeme(config)
+        self.assertIsInstance(default_app.backend, RedisBackend)


### PR DESCRIPTION
In fact, it's appear that celery use a decorator @cached_property
that cache the created result backend set, which is
celery.backends.base.DisabledBackend
This depends of wich import you are doing before pyramid
instanciate the Configurator class.
So to ensure the conf is reloaded, cached_property have to be
deleted.

Also if tasks has been registred, ensure that the backend is used
for those tasks.

Looks like #4
