### PR TITLE
Updated the version number for pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if sys.version_info < (2, 7):
 
 
 setup(name='pyramid_celery',
-      version='1.3',
+      version='1.3.1',
       description='Celery integration with pyramid',
       long_description=README + '\n\n' +  CHANGES,
       classifiers=[


### PR DESCRIPTION
Installing from pip pulls down an older version (also called 1.3)
which doesn't work properly with newer versions of celery (no pcelery
command)
