### PR TITLE
supporting ADMINS parameter in the configuration setup file

### DIFF
--- a/pyramid_celery/loaders.py
+++ b/pyramid_celery/loaders.py
@@ -107,6 +107,15 @@ class INILoader(celery.loaders.base.BaseLoader):
                 split_setting = config_dict[setting].split()
                 config_dict[setting] = split_setting
 
+        # handle admin configuration as a JSON blob
+        if 'ADMINS' in config_dict:
+            try:
+                config_dict['ADMINS'] = json.loads(config_dict['ADMINS'])
+            except ValueError:
+                msg = 'The ADMINS property must be a JSON representation of the Celery ADMIN property.'
+                raise ConfigurationError(msg)
+
+
         beat_config = {}
         route_config = {}
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if sys.version_info < (2, 7):
 
 
 setup(name='pyramid_celery',
-      version='2.0.0',
+      version='2.0.1',
       description='Celery integration with pyramid',
       long_description=README,
       classifiers=[


### PR DESCRIPTION
With this change, you would be able to define error reporting emails using the ADMINS celery configuration, defined in JSON format:

http://celery.readthedocs.org/en/release21-maint/reference/celery.conf.html#sending-e-mails

In the INI, you would set the value:

[celery]
ADMINS = [["John Doe", "john@doe.com"]]
SERVER_EMAIL=errors@doe.com
...

All the other email parameters work as defined.
