### PR TITLE
Added tuple-list config parsing for Celery ADMINS config, with test.

### DIFF
--- a/pyramid_celery/loaders.py
+++ b/pyramid_celery/loaders.py
@@ -107,6 +107,14 @@ class INILoader(celery.loaders.base.BaseLoader):
                 split_setting = config_dict[setting].split()
                 config_dict[setting] = split_setting
 
+        tuple_list_settings = ['ADMINS']
+
+        for setting in tuple_list_settings:
+            if setting in config_dict:
+                items = config_dict[setting].split()
+                tuple_settings = [tuple(item.split(',')) for item in items]
+                config_dict[setting] = tuple_settings
+
         beat_config = {}
         route_config = {}
 

--- a/tests/configs/dev.ini
+++ b/tests/configs/dev.ini
@@ -8,6 +8,9 @@ CELERY_ACCEPT_CONTENT =
   json
   xml
 CELERY_TIMEZONE = America/Los_Angeles
+ADMINS =
+  john,john@initrode.example
+  exceptions,exceptions@majortech.example
 
 [celerybeat:task1]
 # Execute every hour

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -17,6 +17,9 @@ def test_basic_ini():
     schedule = result['CELERYBEAT_SCHEDULE']
 
     assert result['BROKER_URL'] == 'redis://localhost:1337/0'
+    assert result['ADMINS'] == [
+        ('john', 'john@initrode.example'),
+        ('exceptions', 'exceptions@majortech.example')]
     assert schedule['task1']['task'] == 'myapp.tasks.Task1'
     assert schedule['task2']['task'] == 'myapp.tasks.Task2'
     assert schedule['task3']['task'] == 'otherapp.tasks.Task3'


### PR DESCRIPTION
This adds list-of-tuple parsing to the `INILoader` so that configuration settings like [ADMINS](http://docs.celeryproject.org/en/latest/configuration.html#admins) can be correctly read and used by pyramid_celery.

This PR solves #55 by adding the code suggested there and includes an additional test for it.
