### PR TITLE
Use new Celery 4 argument parser (argparse instead of optparse)

### DIFF
--- a/pyramid_celery/__init__.py
+++ b/pyramid_celery/__init__.py
@@ -1,27 +1,23 @@
 from celery import Celery
 from celery import signals
-from optparse import make_option
 from pyramid.paster import bootstrap, setup_logging
 from pyramid_celery.loaders import INILoader
 from pyramid.settings import asbool
 
+
+def add_preload_arguments(parser):
+    parser.add_argument(
+        '-i', '--ini', default=None,
+        help='Paste ini configuration file.'
+    )
+    parser.add_argument(
+        '--ini-var', default=None,
+        help='Comma separated list of key=value to pass to ini.'
+    )
+
+
 celery_app = Celery()
-
-
-celery_app.user_options['preload'].add(
-    make_option(
-        '-i', '--ini',
-        default=None,
-        help='Paste ini configuration file.'),
-)
-
-celery_app.user_options['preload'].add(
-    make_option(
-        '--ini-var',
-        default=None,
-        help='Comma separated list of key=value to pass to ini'),
-)
-
+celery_app.user_options['preload'].add(add_preload_arguments)
 ini_file = None
 
 


### PR DESCRIPTION
Celery 4 no longer recognizes our custom arguments, which makes ini file useless.