### PR TITLE
Fix #66 : show error traceback when pyramid's bootstrap fails

### DIFF
--- a/pyramid_celery/__init__.py
+++ b/pyramid_celery/__init__.py
@@ -102,7 +102,7 @@ def on_preload_parsed(options, **kwargs):
             env = bootstrap(ini_location, options=options)
         else:
             env = bootstrap(ini_location)
-    except:
+    except Exception:
         import traceback
         traceback.print_exc()
         exit(-1)

--- a/pyramid_celery/__init__.py
+++ b/pyramid_celery/__init__.py
@@ -93,14 +93,19 @@ def on_preload_parsed(options, **kwargs):
         exit(-1)
 
     options = {}
-    if ini_vars is not None:
-        for pairs in ini_vars.split(','):
-            key, value = pairs.split('=')
-            options[key] = value
+    try:
+        if ini_vars is not None:
+            for pairs in ini_vars.split(','):
+                key, value = pairs.split('=')
+                options[key] = value
 
-        env = bootstrap(ini_location, options=options)
-    else:
-        env = bootstrap(ini_location)
+            env = bootstrap(ini_location, options=options)
+        else:
+            env = bootstrap(ini_location)
+    except:
+        import traceback
+        traceback.print_exc()
+        exit(-1)
 
     registry = env['registry']
     app = env['app']

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -73,6 +73,17 @@ def test_preload_ini():
 
 
 @pytest.mark.unit
+def test_preload_bad_ini():
+    from pyramid_celery import on_preload_parsed
+    options = {
+        'ini': 'tests/configs/bad.ini',
+        'ini_var': None,
+    }
+    with pytest.raises(SystemExit):
+        on_preload_parsed(options)
+
+
+@pytest.mark.unit
 def test_celery_imports():
     from pyramid_celery import includeme, celery_app
     from pyramid import testing


### PR DESCRIPTION
As said in comment I don't like this solution but at least it works and avoid celery to start with wrong configuration values.