### PR TITLE
Add support for BROKER_TRANSPORT_OPTIONS

### DIFF
--- a/pyramid_celery/loaders.py
+++ b/pyramid_celery/loaders.py
@@ -106,6 +106,13 @@ class INILoader(celery.loaders.base.BaseLoader):
             if setting in config_dict:
                 split_setting = config_dict[setting].split()
                 config_dict[setting] = split_setting
+                
+        dict_settings = ['BROKER_TRANSPORT_OPTIONS']
+
+        for setting in dict_settings:
+            if setting in config_dict:
+                config_dict[setting] = json.loads(config_dict[setting])
+
 
         tuple_list_settings = ['ADMINS']
 

--- a/pyramid_celery/loaders.py
+++ b/pyramid_celery/loaders.py
@@ -107,7 +107,7 @@ class INILoader(celery.loaders.base.BaseLoader):
                 split_setting = config_dict[setting].split()
                 config_dict[setting] = split_setting
                 
-        dict_settings = ['BROKER_TRANSPORT_OPTIONS']
+        dict_settings = ['broker_transport_options']
 
         for setting in dict_settings:
             if setting in config_dict:


### PR DESCRIPTION
Add support for BROKER_TRANSPORT_OPTIONS in Celery 4.1 and up.