### PR TITLE
Added 'master_name' to 'BROKER_TRANSPORT_OPTIONS_MAP'

### DIFF
--- a/pyramid_celery/loaders.py
+++ b/pyramid_celery/loaders.py
@@ -25,6 +25,7 @@ SCHEDULE_TYPE_MAP = {
 BROKER_TRANSPORT_OPTIONS_MAP = {
     'visibility_timeout': int,
     'max_retries': int,
+    'master_name': str,
 }
 
 


### PR DESCRIPTION
This option is necessary to use REDIS replication based on sentinels:

```
[celery]
BROKER_URL = sentinel://:mypassword@sentinel1:26379/1;sentinel://:mypassword@sentinel2:26379/1

[celery:broker_transport_options]
master_name = mymaster
```

More info in https://github.com/celery/kombu/blob/master/kombu/transport/redis.py (see SentinelChannel).

Thanks
